### PR TITLE
Fix CJK line gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ Please download the latest zip files from our [releases page](https://github.com
 | IBM Plex Sans Thai        | [@ibm/plex-sans-thai](https://www.npmjs.com/package/@ibm/plex-sans-thai)               |
 | IBM Plex Sans Thai Looped | [@ibm/plex-sans-thai-looped](https://www.npmjs.com/package/@ibm/plex-sans-thai-looped) |
 | IBM Plex Serif            | [@ibm/plex-serif](https://www.npmjs.com/package/@ibm/plex-serif)                       |
+
+### Line height
+IBM Plex Sans JP, SC, and TC set the `hhea.lineGap` value to `0` to match
+CJK font conventions. Earlier versions used a large line gap which resulted in
+excessive vertical spacing.

--- a/scripts/fix_line_gap.py
+++ b/scripts/fix_line_gap.py
@@ -1,0 +1,39 @@
+import sys
+from fontTools.ttLib import TTFont
+from pathlib import Path
+
+"""Utility to set the hhea.lineGap field to zero.
+
+Usage:
+    python fix_line_gap.py <font_dir> [<font_dir> ...]
+The script searches recursively for TTF, OTF, WOFF, and WOFF2 files
+and updates them in place if the lineGap value differs from zero.
+"""
+
+def fix_font(path: Path) -> bool:
+    try:
+        font = TTFont(str(path))
+        if "hhea" in font:
+            hhea = font["hhea"]
+            if hhea.lineGap != 0:
+                hhea.lineGap = 0
+                font.save(str(path))
+                return True
+    except Exception as e:
+        print(f"Failed to process {path}: {e}")
+    return False
+
+def main(paths):
+    changed = 0
+    for dir_path in paths:
+        for ext in ("*.ttf", "*.otf", "*.woff", "*.woff2"):
+            for font_file in Path(dir_path).rglob(ext):
+                if fix_font(font_file):
+                    changed += 1
+    print(f"Updated {changed} fonts")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python fix_line_gap.py <font_dir> [<font_dir> ...]")
+        sys.exit(1)
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- document zero `lineGap` for CJK fonts
- provide a helper script to update font files
- revert accidental font modifications from prior commit

## Testing
- `yarn install --immutable` *(fails: lockfile would have been modified)*
- `yarn test:e2e:local:no-percy` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685f65cbe930832085d02ba5059cb36c